### PR TITLE
FIX: Filter electricity production domains

### DIFF
--- a/helenservice/api_client.py
+++ b/helenservice/api_client.py
@@ -343,6 +343,7 @@ class HelenApiClient:
         return the newest one.
         """
         active_contracts = list(filter(lambda contract: contract["end_date"] == None or self._date_is_now_or_later(contract["end_date"]), contracts))
+        active_contracts = list(filter(lambda contract: contract["domain"] != "electricity-production", active_contracts))
         if active_contracts.__len__() > 1:
             logging.warn("Found multiple active Helen contracts. Using the newest one.")
             active_contracts.sort(key=lambda contract: datetime.strptime(contract["start_date"], '%Y-%m-%dT%H:%M:%S'), reverse=True)


### PR DESCRIPTION
Small push request to fix multiple contracts, filters out production sites if you also have solar.

This fixes an issue for me when solar production would otherwise be chosen as the active site.