### PR TITLE
Add support for energy transfer contract measurement

### DIFF
--- a/helenservice/api_client.py
+++ b/helenservice/api_client.py
@@ -14,6 +14,7 @@ from dateutil.relativedelta import relativedelta
 class HelenApiClient:
     HELEN_API_URL_V14 = "https://api.omahelen.fi/v14"
     MEASUREMENTS_ENDPOINT = "/measurements/electricity"
+    TRANSFER_ENDPOINT = "/measurements/electricity-transfer"
     SPOT_PRICES_ENDPOINT = MEASUREMENTS_ENDPOINT + "/spot-prices"
     CONTRACT_ENDPOINT = "/contract/list"
 
@@ -145,7 +146,8 @@ class HelenApiClient:
             "allow_transfer": "true"
         }
 
-        measurements_url = self.HELEN_API_URL_V14 + self.MEASUREMENTS_ENDPOINT
+        measurements_url = self._get_measurements_endpoint()
+
         response_json_text = get(
             measurements_url, measurements_params, headers=self._api_request_headers(), timeout=HTTP_READ_TIMEOUT).text
         daily_measurement: MeasurementResponse = MeasurementResponse(
@@ -169,7 +171,7 @@ class HelenApiClient:
             "allow_transfer": "true"
         }
 
-        measurements_url = self.HELEN_API_URL_V14 + self.MEASUREMENTS_ENDPOINT
+        measurements_url = self._get_measurements_endpoint()
         response_json_text = get(
             measurements_url, measurements_params, headers=self._api_request_headers(), timeout=HTTP_READ_TIMEOUT).text
         monthly_measurement: MeasurementResponse = MeasurementResponse(
@@ -194,7 +196,7 @@ class HelenApiClient:
             "allow_transfer": "true"
         }
 
-        measurements_url = self.HELEN_API_URL_V14 + self.MEASUREMENTS_ENDPOINT
+        measurements_url = self._get_measurements_endpoint()
         response_json_text = get(
             measurements_url, measurements_params, headers=self._api_request_headers(), timeout=HTTP_READ_TIMEOUT).text
         hourly_measurement: MeasurementResponse = MeasurementResponse(
@@ -352,3 +354,8 @@ class HelenApiClient:
         end_date = datetime.strptime(end_date_str, '%Y-%m-%dT%H:%M:%S')
         now = datetime.now()
         return end_date >= now
+    
+    def _get_measurements_endpoint(self):
+        if 'domain' in self._latest_active_contract and self._latest_active_contract['domain'] == 'electricity-transfer':
+            return self.HELEN_API_URL_V14 + self.TRANSFER_ENDPOINT
+        return self.HELEN_API_URL_V14 + self.MEASUREMENTS_ENDPOINT

--- a/helenservice/api_response.py
+++ b/helenservice/api_response.py
@@ -18,8 +18,11 @@ class MeasurementData(object):
 
 
 class MeasurementIntervals(object):
-    def __init__(self, electricity: List):
-        self.electricity = list(map(lambda e: MeasurementData(**e), electricity))
+    def __init__(self, electricity: List = None, electricity_transfer: List = None):
+        if electricity is not None:
+            self.electricity = list(map(lambda e: MeasurementData(**e), electricity))
+        elif electricity_transfer is not None:
+            self.electricity = list(map(lambda e: MeasurementData(**e), electricity_transfer))
 
 
 class MeasurementResponse(object):


### PR DESCRIPTION
The following commands now work with energy transfer contracts:
- get_daily_measurements_json
- get_monthly_measurements_json

Should make https://github.com/carohauta/oma-helen-ha-integration/issues/6 work for measurements